### PR TITLE
Revise README for project deprecation and Caddy setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ To create a proxy to an HTTP app for HTTPS for local development, use Caddy.
 
 ## Setting Up Caddy
 
-1. Install Caddy according to the instructions on caddyserver.com
+1. Install Caddy according to the instructions on [caddyserver.com](https://caddyserver.com/)
 2. Run `sudo caddy trust` to install a local certificate authority. This will allow Caddy to create a self-signed certificate.
 3. For your project, create a `caddyfile` as below, replacing the `:80` with the port your server is running on (often `:3000` or `:8000`)
 
 ```caddyfile
+{
+  http_port 8090
+}
 https://localhost {
     tls internal
 
@@ -19,3 +22,5 @@ https://localhost {
 ```
 
 4. To start the proxy, run `caddy run` in the directory where the `caddyfile` lives. You can also adjust hostnames by changing `https://localhost` at the top to whatever hostname you'd like.
+
+Caddy likes to run its own non-secured HTTP server at port 80. The `http_port` command above pushes that non-secured server to another port.

--- a/README.md
+++ b/README.md
@@ -1,84 +1,21 @@
-# https-cert-proxy
+This project is no longer supported. See below for an alternative using Caddy.
 
-Creates a proxy to your HTTP app with HTTPS, using provided certificate files. This is designed as a
-convenience.
+# Alternative
 
-## Setup Instructions
+To create a proxy to an HTTP app for HTTPS for local development, use Caddy.
 
-You'll need to generate a self-signed certificiate, or one from a locally trusted CA.
+## Setting Up Caddy
 
-### macOS
+1. Install Caddy according to the instructions on caddyserver.com
+2. Run `sudo caddy trust` to install a local certificate authority. This will allow Caddy to create a self-signed certificate.
+3. For your project, create a `caddyfile` as below, replacing the `:80` with the port your server is running on (often `:3000` or `:8000`)
 
-The `mkcert` package, available on Homebrew, is very easy to use.
+```caddyfile
+https://localhost {
+    tls internal
 
-1. Ensure you have [Homebrew](https://brew.sh) installed.
-2. Run `brew install mkcert nss`. `mkcert` will create the certificate. `nss` will get Firefox to
-   recognize it. (Other browsers will recognize it automatically.)
-3. Run `mkcert -install` to generate your local CA.
-4. Change to the directory where you'd like to save the certificates. I recommend a `/certificates`
-   directory in your project.
-5. Run `mkcert localhost`.
-6. Ensure that the two generated files, `localhost.pem` and `localhost-key.pem`, are ignored in your
-   source control. They would only be trusted on your local machine, so other users would run into
-   errors.
-
-### Other Operating Systems
-
-Contributions welcome!
-
-## Alternative Hostnames
-It may be useful to use an alternative hostname for your project. For example, if you need to use
-cookies, you may wish to serve from `localhost.YOURDOMAIN.com`. To do so, you'll need to make sure
-the alternative hostname is in your `/etc/hosts` file (or equivalent). In step 5 above, replace
-`localhost` with your full domain, i.e. `mkcert localhost.YOURDOMAIN.com`.
-
-## Usage
-
-In parallel with your development environment, run this as follows:
-
-```shell script
-npx https-cert-proxy --cert path/to/localhost.pem --key path/to/localhost-key.pem
-```
-
-By default, this will proxy your existing `http://localhost:3000` to `https://localhost:8030`. These
-ports can be configured using flags. For example, this will proxy from 80 (the default HTTP port) to
-443 (the default HTTPS port):
-
-```shell script
-npx https-cert-proxy --cert path/to/localhost.pem --key path/to/localhost-key.pem --source 80 --destination 443
-```
-
-I find it easiest to have these scripts in my `package.json`, using the package `concurrently`:
-
-```json
-{
-  "scripts": {
-    "dev": "concurrently -n w: npm:dev-*",
-    "dev-web": "YOUR CURRENT DEV SCRIPT",
-    "dev-ssl": "https-cert-proxy --cert path/to/localhost.pem --key path/to/localhost-key.pem"
-  },
-  "devDependencies": {
-    "concurrently": "^5.1.0",
-    "https-cert-proxy": "^0.0.1"
-  }
+    reverse_proxy localhost:80
 }
 ```
 
-## Configuring with environment variables
-
-If you often run with the same settings, you can set up environment variables in addition to using
-the command-line options. The variables are as follows:
-
-| Variable          | Setting              |
-|-------------------|----------------------|
-| `HCP_SOURCE`      | Source port          |
-| `HCP_DESTINATION` | Destination port     |
-| `HCP_CERTFILE`    | The certificate file |
-| `HCP_KEYFILE`     | The key file         |
-
-If you set the `HCP_CERTFILE` and `HCP_KEYFILE` variables, you do not need to use the `--cert` and
-`--key` command-line options.
-
-## Copyright/License
-
-Copyright (c) 2020-21 Todd Dukart. Licensed under the BSD-3-Clause.
+4. To start the proxy, run `caddy run` in the directory where the `caddyfile` lives. You can also adjust hostnames by changing `https://localhost` at the top to whatever hostname you'd like.


### PR DESCRIPTION
Update README to indicate project is no longer supported and provide alternative using Caddy.